### PR TITLE
Add documentation for creating new response areas

### DIFF
--- a/docs/advanced/response_areas/create.md
+++ b/docs/advanced/response_areas/create.md
@@ -1,0 +1,35 @@
+# Create a New Response Area
+
+The
+[`response-area-template`](https://github.com/lambda-feedback/response-area-template)
+repository provides a pre-configured base for developing a new response
+area. The template includes the [sandbox](sandbox.md) development tool which you
+can use to view and test your response area.
+
+## Prerequisites
+
+You should be familiar with [Git](https://git-scm.com/),
+[TypeScript](https://www.typescriptlang.org) and [React](https://react.dev).
+
+## Implement your Response Area
+
+1. [Create a new repository](https://github.com/new?template_name=response-area-template&template_owner=lambda-feedback)
+   based on the template and clone it to your development machine.
+
+1. Start the sandbox:
+    ```
+    $ ./start_sandbox
+    ```
+
+1. Implement your response area by editing the following files:
+
+    - `components/Input.component.tsx`
+
+        This React component should enable a student to enter their response.
+
+    - `components/Wizard.component.tsx`
+
+        This React component should allow a teacher to configure the response
+        area.
+
+1. Commit and push your changes to your repository on GitHub.

--- a/docs/advanced/response_areas/sandbox.md
+++ b/docs/advanced/response_areas/sandbox.md
@@ -1,0 +1,1 @@
+# Response Area Sandbox

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,8 @@ nav:
       - "advanced/index.md"
       - Response Areas:
           - Overview: "advanced/response_areas/overview.md"
+          - Create a New Response Area: "advanced/response_areas/create.md"
+          - Response Area Sandbox: "advanced/response_areas/sandbox.md"
       - Evaluation Functions:
           - Quickstart Guide: "advanced/evaluation_functions/quickstart.md"
           - General Specification: "advanced/evaluation_functions/specification.md"


### PR DESCRIPTION
This PR adds documentation pages under `advanced/response_areas` which explain how to create a new response area using the template repository and sandbox.